### PR TITLE
load config from environment

### DIFF
--- a/src/main/java/com/sbuslab/utils/config/ConfigLoader.java
+++ b/src/main/java/com/sbuslab/utils/config/ConfigLoader.java
@@ -16,7 +16,7 @@ import com.sbuslab.utils.FileUtils;
 /**
  * -Dconfig.localfile=/path/to/local-config-fiel.conf
  * or
- * export CONFIG_LOCALFILE=/path/to/local-config-fiel.conf
+ * export SBUS_CONFIG_LOCALFILE=/path/to/local-config-fiel.conf
  */
 @Slf4j
 public class ConfigLoader {

--- a/src/main/java/com/sbuslab/utils/config/ConfigLoader.java
+++ b/src/main/java/com/sbuslab/utils/config/ConfigLoader.java
@@ -11,14 +11,23 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.sbuslab.utils.FileUtils;
 
-
+/**
+ * config.localfile - позволяет задать локальную конфигурацию для каждого проекта через VM options
+ * (-Dconfig.localfile=путь_к_настройкам)
+ * <p>
+ * LOCALFILE_SBUS_CONFIG - позволяет задать локальную конфигурацию для всех проектов разом на уровне окружения,
+ * при этом сохраняется приоритет индвидуальной конфигурации над конфигурацией окружения ОС.
+ */
 @Slf4j
 public class ConfigLoader {
 
     public static Config load() {
-        String configPaths = System.getProperty("config.localfile", "")
-            .replace("/", File.separator)
-            .replace("\\", File.separator);
+        String localfileSbusConfig = System.getenv("LOCALFILE_SBUS_CONFIG"); //to be able to overwrite the configuration in docker
+        String configPaths = System.getProperty("config.localfile",
+                localfileSbusConfig == null
+                        ? "" : localfileSbusConfig)
+                .replace("/", File.separator)
+                .replace("\\", File.separator);
 
         try {
             String secretsUrl = System.getenv("SECRET_CONFIG_URL");

--- a/src/main/java/com/sbuslab/utils/config/ConfigLoader.java
+++ b/src/main/java/com/sbuslab/utils/config/ConfigLoader.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Optional;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -11,21 +12,18 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.sbuslab.utils.FileUtils;
 
+
 /**
- * config.localfile - позволяет задать локальную конфигурацию для каждого проекта через VM options
- * (-Dconfig.localfile=путь_к_настройкам)
- * <p>
- * LOCALFILE_SBUS_CONFIG - позволяет задать локальную конфигурацию для всех проектов разом на уровне окружения,
- * при этом сохраняется приоритет индвидуальной конфигурации над конфигурацией окружения ОС.
+ * -Dconfig.localfile=/path/to/local-config-fiel.conf
+ * or
+ * export CONFIG_LOCALFILE=/path/to/local-config-fiel.conf
  */
 @Slf4j
 public class ConfigLoader {
 
     public static Config load() {
-        String localfileSbusConfig = System.getenv("LOCALFILE_SBUS_CONFIG"); //to be able to overwrite the configuration in docker
         String configPaths = System.getProperty("config.localfile",
-                localfileSbusConfig == null
-                        ? "" : localfileSbusConfig)
+            Optional.ofNullable(System.getenv("SBUS_CONFIG_LOCALFILE")).orElse(""))
                 .replace("/", File.separator)
                 .replace("\\", File.separator);
 


### PR DESCRIPTION
Профит:
1) Позволяет задать локальную конфигурацию для всех проектов разом на уровне окружения, при этом сохраняется приоритет индвидуальной конфигурации над конфигурацией окружение ОС
2) Если захочется прокинуть конфигурацию в docker для нужд test container'ов, то это получится через environment конфигурацию указанную в переменной LOCALFILE_SBUS_CONFIG