### PR TITLE
Support multiple locations for DB migrations

### DIFF
--- a/src/main/java/com/sbuslab/utils/db/DbMigration.java
+++ b/src/main/java/com/sbuslab/utils/db/DbMigration.java
@@ -36,7 +36,14 @@ public class DbMigration {
                 .outOfOrder(true);
 
             if (conf.hasPath("locations")) {
-                flywayConf.locations(conf.getString("locations"));
+                String[] locations = null;
+                try {
+                    locations = conf.getStringList("locations").stream().toArray(String[]::new);
+                } catch(ConfigException.WrongType e) {
+                   locations = new String[]{conf.getString("locations")};
+                }
+
+                flywayConf.locations(locations);
             }
 
             if (conf.hasPath("table")) {


### PR DESCRIPTION
Current implementations allows only to specify single location for DB scripts this is limiting factor for us. 
We have use case where we have to have some additional migrations for specific customers. 