### PR TITLE
Add nonproxy-hosts configuration to sbus http client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,4 +149,6 @@ dependencies {
     testImplementation 'org.scalatest:scalatest_2.12:3.0.5'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'io.qala.datagen:qala-datagen:2.5.1'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.33.2'
+    testImplementation 'co.copper:common-test:1.0.+'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -150,5 +150,4 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'io.qala.datagen:qala-datagen:2.5.1'
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.33.2'
-    testImplementation 'co.copper:common-test:1.0.+'
 }

--- a/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
@@ -155,7 +155,7 @@ public abstract class DefaultConfiguration implements ApplicationContextAware {
     }
 
     private static List<String> parseNonProxyHostsConfig(String nonProxyHosts){
-        if(!StringUtils.hasLength(nonProxyHosts)){
+        if(!StringUtils.hasLength(nonProxyHosts)) {
             return Collections.emptyList();
         }
         String[] nonProxyHostsArray = nonProxyHosts.split("\\|");

--- a/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
@@ -144,11 +144,12 @@ public abstract class DefaultConfiguration implements ApplicationContextAware {
             .setFollowRedirect(conf.getBoolean("follow-redirect"));
 
         if (!conf.getString("proxy.host").isEmpty()) {
-            ProxyServer.Builder builder = new ProxyServer.Builder(conf.getString("proxy.host"), conf.getInt("proxy.port"))
+            ProxyServer.Builder proxyServerBuilder = new ProxyServer.Builder(conf.getString("proxy.host"), conf.getInt("proxy.port"))
                 .setProxyType(ProxyType.HTTP);
             List<String> nonProxyHostList = parseNonProxyHostsConfig(conf.getString("proxy.nonproxy-hosts"));
-            builder.setNonProxyHosts(nonProxyHostList);
-            bldr.setProxyServer(builder);
+            proxyServerBuilder.setNonProxyHosts(nonProxyHostList);
+            ProxyServer proxyServer = proxyServerBuilder.build();
+            bldr.setProxyServer(proxyServer);
         }
 
         return Dsl.asyncHttpClient(bldr);

--- a/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
@@ -159,7 +159,7 @@ public abstract class DefaultConfiguration implements ApplicationContextAware {
             return Collections.emptyList();
         }
         String[] nonProxyHostsArray = nonProxyHosts.split("\\|");
-        List<String> nonProxyHostList= Arrays.stream(nonProxyHostsArray).collect(Collectors.toList());
+        List<String> nonProxyHostList= Arrays.stream(nonProxyHostsArray).map(host -> host.trim()).collect(Collectors.toList());
         return nonProxyHostList;
     }
 

--- a/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
@@ -146,7 +146,7 @@ public abstract class DefaultConfiguration implements ApplicationContextAware {
         if (!conf.getString("proxy.host").isEmpty()) {
             ProxyServer.Builder builder = new ProxyServer.Builder(conf.getString("proxy.host"), conf.getInt("proxy.port"))
                 .setProxyType(ProxyType.HTTP);
-            List<String> nonProxyHostList = parseNonProxyHostsConfig(conf.getString("nonproxy-hosts"));
+            List<String> nonProxyHostList = parseNonProxyHostsConfig(conf.getString("proxy.nonproxy-hosts"));
             builder.setNonProxyHosts(nonProxyHostList);
             bldr.setProxyServer(builder);
         }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -58,7 +58,7 @@ sbuslab {
     proxy {
       host = ""
       port = 1080
-      nonproxy-hosts = ""
+      nonproxy-hosts = "" # Hostnames are separated by | character. Example: "*.copper.co|api.example.com|localhost|127.0.0.1"
     }
   }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -58,7 +58,7 @@ sbuslab {
     proxy {
       host = ""
       port = 1080
-      non-proxy-hosts = []
+      non-proxy-hosts = []  # list of hosts that will be ignored by the proxy server, example: ["localhost", "127.0.0.1"]
     }
   }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -58,7 +58,7 @@ sbuslab {
     proxy {
       host = ""
       port = 1080
-      nonproxy-hosts = "" # Hostnames are separated by | character. Example: "*.copper.co|api.example.com|localhost|127.0.0.1"
+      non-proxy-hosts = []
     }
   }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -58,6 +58,7 @@ sbuslab {
     proxy {
       host = ""
       port = 1080
+      nonproxy-hosts = ""
     }
   }
 

--- a/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
+++ b/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
@@ -3,11 +3,13 @@ package com.sbuslab.utils
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
-import com.sbuslab.utils.config.DefaultConfiguration
 import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.junit.JUnitRunner
+
+import com.sbuslab.utils.config.DefaultConfiguration
+
 
 @RunWith(classOf[JUnitRunner])
 class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {
@@ -17,6 +19,7 @@ class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {
   // Start 2 http servers
   // proxyServer act as proxy
   val proxyServer = new WireMockServer(options.dynamicPort())
+
   // dummy http server refer to a regular server
   val dummyHttpServer = new WireMockServer(options.dynamicPort())
 
@@ -28,7 +31,7 @@ class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {
       |  sbuslab.http-client.proxy {
       |      host = "localhost"
       |      port = ${proxyServer.port()}
-      |      nonproxy-hosts = ""
+      |      non-proxy-hosts = []
       |   }
       |}""".stripMargin
   )
@@ -48,7 +51,7 @@ class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {
       |  sbuslab.http-client.proxy {
       |      host = "localhost"
       |      port = ${proxyServer.port()}
-      |      nonproxy-hosts = "localhost|127.0.0.1"
+      |      non-proxy-hosts = ["localhost", "127.0.0.1"]
       |   }
       |}""".stripMargin
   )

--- a/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
+++ b/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
@@ -1,15 +1,13 @@
 package com.sbuslab.utils
 
-import co.copper.test.wiremock.WireMocking
-import com.github.tomakehurst.wiremock.{WireMockServer, client}
-import com.github.tomakehurst.wiremock.client.{WireMock, WireMockBuilder}
-import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.sbuslab.utils.config.DefaultConfiguration
 import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 @RunWith(classOf[JUnitRunner])
 class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {

--- a/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
+++ b/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
@@ -14,9 +14,13 @@ class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {
   val ProxyResponse: String = "i_am_proxy_server"
   val DummyServerResponse: String = "i_am_dummy_server"
 
+  // Start 2 http servers
+  // proxyServer act as proxy
   val proxyServer = new WireMockServer(options.dynamicPort())
+  // dummy http server refer to a regular server
   val dummyHttpServer = new WireMockServer(options.dynamicPort())
 
+  //in this case all http calls goes through proxyServer. We should see proxyServer response instead of actual server.
   test("verify that request goes through proxy") {
 
     val config = ConfigFactory.parseString(
@@ -35,6 +39,8 @@ class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {
     assertResult(ProxyResponse) { response.getResponseBody }
   }
 
+  // in this case localhost is in non proxy hosts. So call goes directly to dummyHttpServer, proxy is ignored.
+  // we should see response from dummy http server instead of proxy.
   test("verify that proxy is ignored") {
 
     val config = ConfigFactory.parseString(

--- a/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
+++ b/src/test/scala/com/sbuslab/utils/AsyncHttpClientTest.scala
@@ -1,0 +1,73 @@
+package com.sbuslab.utils
+
+import co.copper.test.wiremock.WireMocking
+import com.github.tomakehurst.wiremock.{WireMockServer, client}
+import com.github.tomakehurst.wiremock.client.{WireMock, WireMockBuilder}
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.sbuslab.utils.config.DefaultConfiguration
+import com.typesafe.config.ConfigFactory
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class AsyncHttpClientTest extends FunSuite with Logging with BeforeAndAfterAll {
+  val ProxyResponse: String = "i_am_proxy_server"
+  val DummyServerResponse: String = "i_am_dummy_server"
+
+  val proxyServer = new WireMockServer(options.dynamicPort())
+  val dummyHttpServer = new WireMockServer(options.dynamicPort())
+
+  test("verify that request goes through proxy") {
+
+    val config = ConfigFactory.parseString(
+    s"""{
+      |  sbuslab.http-client.proxy {
+      |      host = "localhost"
+      |      port = ${proxyServer.port()}
+      |      nonproxy-hosts = ""
+      |   }
+      |}""".stripMargin
+  )
+    .withFallback(ConfigFactory.load("reference.conf"))
+
+    val httpClient = DefaultConfiguration.getAsyncHttpClient(config)
+    val response = httpClient.executeRequest(httpClient.prepareGet(s"http://localhost:${dummyHttpServer.port()}/").build()).get()
+    assertResult(ProxyResponse) { response.getResponseBody }
+  }
+
+  test("verify that proxy is ignored") {
+
+    val config = ConfigFactory.parseString(
+    s"""{
+      |  sbuslab.http-client.proxy {
+      |      host = "localhost"
+      |      port = ${proxyServer.port()}
+      |      nonproxy-hosts = "localhost|127.0.0.1"
+      |   }
+      |}""".stripMargin
+  )
+    .withFallback(ConfigFactory.load("reference.conf"))
+
+    val httpClient = DefaultConfiguration.getAsyncHttpClient(config)
+    val response = httpClient.executeRequest(httpClient.prepareGet(s"http://localhost:${dummyHttpServer.port()}/").build()).get()
+    assertResult(DummyServerResponse) { response.getResponseBody }
+  }
+
+  override def beforeAll(): Unit = {
+    proxyServer.start()
+    dummyHttpServer.start()
+
+    proxyServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/")).willReturn(WireMock.aResponse.withBody(ProxyResponse)))
+    dummyHttpServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/")).willReturn(WireMock.aResponse.withBody(DummyServerResponse)))
+
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll
+    proxyServer.stop()
+    dummyHttpServer.stop()
+  }
+}


### PR DESCRIPTION
Customer wants to exclude some hosts from proxy. 
* Configuration is given as single string, multiple hostnames are separated by | character. This is done so to use same convention as java's http.nonProxyHosts jvm parameter.