### PR TITLE
STTINT-723 Disabling memcache connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,9 +133,13 @@ dependencies {
 
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
 
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.scalatest:scalatest_2.12:3.0.5'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'io.qala.datagen:qala-datagen:2.5.1'
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.33.2'
+    testImplementation 'io.qala.datagen:qala-datagen:2.5.1'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
+    testImplementation 'org.scalatest:scalatest_2.12:3.0.5'
+    testImplementation 'org.springframework.boot:spring-boot-test:2.7.0'
+    testImplementation 'org.springframework:spring-test:5.3.20'
+
 }

--- a/src/main/java/com/sbuslab/utils/config/MemcachedConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/MemcachedConfiguration.java
@@ -1,0 +1,58 @@
+package com.sbuslab.utils.config;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.typesafe.config.Config;
+import net.spy.memcached.AddrUtil;
+import net.spy.memcached.ConnectionFactory;
+import net.spy.memcached.ConnectionFactoryBuilder;
+import net.spy.memcached.DefaultHashAlgorithm;
+import net.spy.memcached.FailureMode;
+import net.spy.memcached.MemcachedClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import com.sbuslab.utils.config.memcached.NoopConnectionFactory;
+
+
+@Configuration
+public abstract class MemcachedConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MemcachedConfiguration.class);
+
+    @Bean
+    @Lazy
+    public MemcachedClient getMemcachedClient(Config config) throws IOException {
+        final Config memcacheConfig = config.getConfig("sbuslab.memcache");
+        final ConnectionFactory cf;
+        final List<String> hosts;
+        if (DefaultConfiguration.DISABLED_MEMOIZE_CACHE) {
+            LOG.info("Caching is disabled.");
+            cf = new NoopConnectionFactory();
+            hosts = Collections.singletonList("127.0.0.1:11211");
+        } else {
+            LOG.info("Caching is enabled.");
+            cf = new ConnectionFactoryBuilder()
+                    .setDaemon(true)
+                    .setShouldOptimize(true)
+                    .setFailureMode(FailureMode.Redistribute)
+                    .setHashAlg(DefaultHashAlgorithm.KETAMA_HASH)
+                    .setLocatorType(ConnectionFactoryBuilder.Locator.CONSISTENT)
+                    .setOpTimeout(memcacheConfig.getDuration("timeout", TimeUnit.MILLISECONDS))
+                    .setMaxReconnectDelay(memcacheConfig.getDuration("max-reconnect-delay", TimeUnit.SECONDS))
+                    .setProtocol(ConnectionFactoryBuilder.Protocol.BINARY)
+                    .build();
+            hosts = memcacheConfig.getStringList("hosts");
+        }
+
+        return new MemcachedClient(cf, AddrUtil.getAddresses(hosts));
+    }
+
+}

--- a/src/main/java/com/sbuslab/utils/config/memcached/NoopConnectionFactory.java
+++ b/src/main/java/com/sbuslab/utils/config/memcached/NoopConnectionFactory.java
@@ -1,0 +1,153 @@
+package com.sbuslab.utils.config.memcached;
+
+import net.spy.memcached.*;
+import net.spy.memcached.auth.AuthDescriptor;
+import net.spy.memcached.metrics.MetricCollector;
+import net.spy.memcached.metrics.MetricType;
+import net.spy.memcached.ops.*;
+import net.spy.memcached.tapmessage.RequestMessage;
+import net.spy.memcached.tapmessage.TapOpcode;
+import net.spy.memcached.transcoders.Transcoder;
+
+import javax.security.auth.callback.CallbackHandler;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.SocketChannel;
+import java.util.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A {@link ConnectionFactory} which allows not to connect to a memcached instance.
+ * Useful in cases where caching is disabled.
+ */
+public class NoopConnectionFactory implements ConnectionFactory {
+
+    @Override
+    public MemcachedConnection createConnection(List<InetSocketAddress> addrs) throws IOException {
+        return new MemcachedConnection(1, this,
+                Collections.emptyList(), Collections.emptyList(),
+                FailureMode.Cancel, getOperationFactory());
+    }
+
+    @Override
+    public MemcachedNode createMemcachedNode(SocketAddress sa, SocketChannel c, int bufSize) {
+        return null;
+    }
+
+    @Override
+    public BlockingQueue<Operation> createOperationQueue() {
+        return null;
+    }
+
+    @Override
+    public BlockingQueue<Operation> createReadOperationQueue() {
+        return null;
+    }
+
+    @Override
+    public BlockingQueue<Operation> createWriteOperationQueue() {
+        return null;
+    }
+
+    @Override
+    public long getOpQueueMaxBlockTime() {
+        return 0;
+    }
+
+    @Override
+    public ExecutorService getListenerExecutorService() {
+        return null;
+    }
+
+    @Override
+    public boolean isDefaultExecutorService() {
+        return false;
+    }
+
+    @Override
+    public NodeLocator createLocator(List<MemcachedNode> nodes) {
+        return new NoopNodeLocator();
+    }
+
+    @Override
+    public OperationFactory getOperationFactory() {
+        return new NoopOperationFactory();
+    }
+
+    @Override
+    public long getOperationTimeout() {
+        return 1L;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return false;
+    }
+
+    @Override
+    public boolean useNagleAlgorithm() {
+        return false;
+    }
+
+    @Override
+    public Collection<ConnectionObserver> getInitialObservers() {
+        return null;
+    }
+
+    @Override
+    public FailureMode getFailureMode() {
+        return null;
+    }
+
+    @Override
+    public Transcoder<Object> getDefaultTranscoder() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public int getReadBufSize() {
+        return 0;
+    }
+
+    @Override
+    public HashAlgorithm getHashAlg() {
+        return null;
+    }
+
+    @Override
+    public long getMaxReconnectDelay() {
+        return 0;
+    }
+
+    @Override
+    public AuthDescriptor getAuthDescriptor() {
+        return null;
+    }
+
+    @Override
+    public int getTimeoutExceptionThreshold() {
+        return 0;
+    }
+
+    @Override
+    public MetricType enableMetrics() {
+        return MetricType.OFF;
+    }
+
+    @Override
+    public MetricCollector getMetricCollector() {
+        return null;
+    }
+
+    @Override
+    public long getAuthWaitTime() {
+        return 0;
+    }
+}

--- a/src/main/java/com/sbuslab/utils/config/memcached/NoopNodeLocator.java
+++ b/src/main/java/com/sbuslab/utils/config/memcached/NoopNodeLocator.java
@@ -1,0 +1,37 @@
+package com.sbuslab.utils.config.memcached;
+
+import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.NodeLocator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class NoopNodeLocator implements NodeLocator {
+
+    @Override
+    public MemcachedNode getPrimary(String k) {
+        return null;
+    }
+
+    @Override
+    public Iterator<MemcachedNode> getSequence(String k) {
+        return null;
+    }
+
+    @Override
+    public Collection<MemcachedNode> getAll() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public NodeLocator getReadonlyCopy() {
+        return null;
+    }
+
+    @Override
+    public void updateLocator(List<MemcachedNode> nodes) {
+
+    }
+}

--- a/src/main/java/com/sbuslab/utils/config/memcached/NoopOperationFactory.java
+++ b/src/main/java/com/sbuslab/utils/config/memcached/NoopOperationFactory.java
@@ -1,0 +1,157 @@
+package com.sbuslab.utils.config.memcached;
+
+import net.spy.memcached.OperationFactory;
+import net.spy.memcached.ops.*;
+import net.spy.memcached.tapmessage.RequestMessage;
+import net.spy.memcached.tapmessage.TapOpcode;
+
+import javax.security.auth.callback.CallbackHandler;
+import java.util.Collection;
+import java.util.Map;
+
+public class NoopOperationFactory implements OperationFactory {
+    @Override
+    public NoopOperation noop(OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public DeleteOperation delete(String key, DeleteOperation.Callback callback) {
+        return null;
+    }
+
+    @Override
+    public DeleteOperation delete(String key, long cas, DeleteOperation.Callback callback) {
+        return null;
+    }
+
+    @Override
+    public UnlockOperation unlock(String key, long casId, OperationCallback operationCallback) {
+        return null;
+    }
+
+    @Override
+    public ObserveOperation observe(String key, long casId, int index, ObserveOperation.Callback operationCallback) {
+        return null;
+    }
+
+    @Override
+    public FlushOperation flush(int delay, OperationCallback operationCallback) {
+        return null;
+    }
+
+    @Override
+    public GetAndTouchOperation getAndTouch(String key, int expiration, GetAndTouchOperation.Callback cb) {
+        return null;
+    }
+
+    @Override
+    public GetOperation get(String key, GetOperation.Callback callback) {
+        return null;
+    }
+
+    @Override
+    public ReplicaGetOperation replicaGet(String key, int index, ReplicaGetOperation.Callback callback) {
+        return null;
+    }
+
+    @Override
+    public ReplicaGetsOperation replicaGets(String key, int index, ReplicaGetsOperation.Callback callback) {
+        return null;
+    }
+
+    @Override
+    public GetlOperation getl(String key, int exp, GetlOperation.Callback callback) {
+        return null;
+    }
+
+    @Override
+    public GetsOperation gets(String key, GetsOperation.Callback callback) {
+        return null;
+    }
+
+    @Override
+    public GetOperation get(Collection<String> keys, GetOperation.Callback cb) {
+        return null;
+    }
+
+    @Override
+    public StatsOperation keyStats(String key, StatsOperation.Callback cb) {
+        return null;
+    }
+
+    @Override
+    public MutatorOperation mutate(Mutator m, String key, long by, long def, int exp, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public StatsOperation stats(String arg, StatsOperation.Callback cb) {
+        return null;
+    }
+
+    @Override
+    public StoreOperation store(StoreType storeType, String key, int flags, int exp, byte[] data, StoreOperation.Callback cb) {
+        return null;
+    }
+
+    @Override
+    public TouchOperation touch(String key, int expiration, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public ConcatenationOperation cat(ConcatenationType catType, long casId, String key, byte[] data, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public CASOperation cas(StoreType t, String key, long casId, int flags, int exp, byte[] data, StoreOperation.Callback cb) {
+        return null;
+    }
+
+    @Override
+    public VersionOperation version(OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public SASLMechsOperation saslMechs(OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public SASLAuthOperation saslAuth(String[] mech, String serverName, Map<String, ?> props, CallbackHandler cbh, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public SASLStepOperation saslStep(String[] mech, byte[] challenge, String serverName, Map<String, ?> props, CallbackHandler cbh, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public Collection<Operation> clone(KeyedOperation op) {
+        return null;
+    }
+
+    @Override
+    public TapOperation tapBackfill(String id, long date, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public TapOperation tapCustom(String id, RequestMessage message, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public TapOperation tapAck(TapOpcode opcode, int opaque, OperationCallback cb) {
+        return null;
+    }
+
+    @Override
+    public TapOperation tapDump(String id, OperationCallback cb) {
+        return null;
+    }
+}

--- a/src/main/scala/com/sbuslab/utils/MemcacheSupport.scala
+++ b/src/main/scala/com/sbuslab/utils/MemcacheSupport.scala
@@ -6,13 +6,13 @@ import scala.concurrent.duration._
 import scala.util.{Success, Try}
 import scala.util.control.NonFatal
 
+import com.sbuslab.utils.config.DefaultConfiguration
 import net.spy.memcached.internal._
 import net.spy.memcached.MemcachedClient
 
-
 trait MemcacheSupport {
 
-  protected val disabledMemoizeMemcached = sys.env.getOrElse("DISABLED_MEMOIZE_CACHE", "false") == "true"
+  protected val disabledMemoizeMemcached = DefaultConfiguration.DISABLED_MEMOIZE_CACHE
 
   private val cacheLoading = new ConcurrentHashMap[String, Future[Any]]()
 

--- a/src/main/scala/com/sbuslab/utils/Memoize.scala
+++ b/src/main/scala/com/sbuslab/utils/Memoize.scala
@@ -6,13 +6,14 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
+import com.sbuslab.utils.config.DefaultConfiguration
 
 trait Memoize {
 
   case class CachedObject(expiredAt: Long, obj: Any)
 
   private val memoizeCache = new ConcurrentHashMap[String, CachedObject]()
-  private val disabledMemoizeCache = sys.env.getOrElse("DISABLED_MEMOIZE_CACHE", "false") == "true"
+  private val disabledMemoizeCache = DefaultConfiguration.DISABLED_MEMOIZE_CACHE
 
   private val fallbackMaxTtl = 1.day
 

--- a/src/test/java/com/sbuslab/utils/config/MemcachedConfigurationTest.java
+++ b/src/test/java/com/sbuslab/utils/config/MemcachedConfigurationTest.java
@@ -1,0 +1,49 @@
+package com.sbuslab.utils.config;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import net.spy.memcached.MemcachedClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@SpringBootTest(classes = { MemcachedConfigurationTest.TestConfig.class, MemcachedConfiguration.class })
+@RunWith(SpringRunner.class)
+public class MemcachedConfigurationTest {
+
+    @TestConfiguration
+    public static class TestConfig {
+
+        @Bean
+        @Primary
+        public Config config() {
+            return ConfigFactory.parseMap(
+                    Map.of("sbuslab", Map.of(
+                            "memcache", Map.of(
+                                    "timeout", 1000000,
+                                    "max-reconnect-delay", 1000000,
+                                    "hosts", List.of("1.2.3.4:11211")))));
+        }
+    }
+
+    @Autowired
+    private MemcachedClient memcachedClient;
+
+    @Test
+    public void doesNotConnectToMemcachedWhenCachingDisabled() {
+        assumeTrue(DefaultConfiguration.DISABLED_MEMOIZE_CACHE);
+        assertTrue(memcachedClient.getUnavailableServers().isEmpty());
+    }
+
+}


### PR DESCRIPTION
Created the new `MemcachedConfiguration` class which takes care of creating the `MemcachedClient` bean. If the `DISABLED_MEMOIZE_CACHE` flag is active, the client is created with a noop connection factory that does not connect anywhere.
Moved the resolution of the `DISABLED_MEMOIZE_CACHE` flag to a single place inside `DefaultConfiguration`; modified dependent code accordingly.
Created the `MemcachedConfigurationTest` which tests that `MemcachedClient` does not try to connect to an instance if caching is disabled. Added Spring & Mockito test dependencies.