### PR TITLE
Enable Redis encryption

### DIFF
--- a/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
@@ -159,18 +159,20 @@ public abstract class DefaultConfiguration implements ApplicationContextAware {
     public static StatefulRedisClusterConnection<String, String> getRedisClient(Config config) {
         Config conf = config.getConfig("sbuslab.redis");
 
-        final int port = conf.hasPath("port") ? conf.getInt("port") : 6379;
         RedisURI redisURI = RedisURI.Builder.redis(conf.getString("host"))
-            .withPort(port)
+            .withPort(conf.getInt("port"))
             .withSsl(conf.getBoolean("ssl"))
             .withVerifyPeer(false)
             .build();
 
-        if (conf.hasPath("password")) {
-            redisURI.setPassword(conf.getString("password").toCharArray());
+        final String password = conf.getString("password");
+        if (!password.isEmpty()) {
+            redisURI.setPassword(password.toCharArray());
         }
-        if (conf.hasPath("user")) {
-            redisURI.setUsername(conf.getString("user"));
+
+        final String user = conf.getString("user");
+        if (!user.isEmpty()) {
+            redisURI.setUsername(user);
         }
 
         RedisClusterClient clusterClient = RedisClusterClient.create(redisURI);

--- a/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
@@ -159,7 +159,9 @@ public abstract class DefaultConfiguration implements ApplicationContextAware {
     public static StatefulRedisClusterConnection<String, String> getRedisClient(Config config) {
         Config conf = config.getConfig("sbuslab.redis");
 
+        final int port = conf.hasPath("port") ? conf.getInt("port") : 6379;
         RedisURI redisURI = RedisURI.Builder.redis(conf.getString("host"))
+            .withPort(port)
             .withSsl(conf.getBoolean("ssl"))
             .withVerifyPeer(false)
             .build();

--- a/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
+++ b/src/main/java/com/sbuslab/utils/config/DefaultConfiguration.java
@@ -164,9 +164,11 @@ public abstract class DefaultConfiguration implements ApplicationContextAware {
             .withVerifyPeer(false)
             .build();
 
-        if (conf.hasPath("user") && conf.hasPath("password")) {
-            redisURI.setUsername(conf.getString("user"));
+        if (conf.hasPath("password")) {
             redisURI.setPassword(conf.getString("password").toCharArray());
+        }
+        if (conf.hasPath("user")) {
+            redisURI.setUsername(conf.getString("user"));
         }
 
         RedisClusterClient clusterClient = RedisClusterClient.create(redisURI);

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -72,5 +72,8 @@ sbuslab {
   redis {
     host = "0.0.0.0"
     port = 6379
+    ssl = false
+    user = ""
+    password = ""
   }
 }


### PR DESCRIPTION
Modified the creation of the Redis client bean (pre-6.x Redis versions only allow auth via password).