### PR TITLE
STTINT-947 Allow dynamic logging

### DIFF
--- a/src/main/java/com/sbuslab/utils/config/logger/LoggerConfigurationData.java
+++ b/src/main/java/com/sbuslab/utils/config/logger/LoggerConfigurationData.java
@@ -1,0 +1,10 @@
+package com.sbuslab.utils.config.logger;
+
+import lombok.Value;
+
+@Value
+public class LoggerConfigurationData {
+    String loggerName;
+
+    String logLevel;
+}

--- a/src/main/java/com/sbuslab/utils/config/logger/LoggerConfigurationParser.java
+++ b/src/main/java/com/sbuslab/utils/config/logger/LoggerConfigurationParser.java
@@ -1,0 +1,38 @@
+package com.sbuslab.utils.config.logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class LoggerConfigurationParser {
+
+    public static Set<LoggerConfigurationData> parseLoggersConfiguration(Config config) {
+        return parseLoggersConfiguration(config.getObject("sbuslab.loggers"), "")
+                .collect(Collectors.toSet());
+    }
+
+    private static Stream<LoggerConfigurationData> parseLoggersConfiguration(ConfigObject config, String currentLoggerNamePrefix) {
+        return config.entrySet().stream().flatMap(entry -> {
+            final String key = entry.getKey();
+            final String currentLoggerName = currentLoggerNamePrefix.isEmpty() ? key : currentLoggerNamePrefix + "." + key;
+            final ConfigValue value = entry.getValue();
+            if (value.valueType() == ConfigValueType.STRING) {
+                return Stream.of(new LoggerConfigurationData(
+                        currentLoggerName,
+                        value.atPath("/").getString("/")));
+            } else {
+                return parseLoggersConfiguration(value.atPath("/").getObject("/"), currentLoggerName);
+            }
+        });
+    }
+}

--- a/src/main/resources/default-json-logback.xml
+++ b/src/main/resources/default-json-logback.xml
@@ -28,7 +28,8 @@
 
   <include resource="logback-logger-excludes.xml" />
 
-  <root level="TRACE">
+  <variable name="ROOT_LOG_LEVEL" value="${ROOT_LOG_LEVEL:-TRACE}" />
+  <root level="${ROOT_LOG_LEVEL}">
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="METRICS"/>
   </root>

--- a/src/test/java/com/sbuslab/utils/config/logger/LoggerConfigurationParserTest.java
+++ b/src/test/java/com/sbuslab/utils/config/logger/LoggerConfigurationParserTest.java
@@ -1,0 +1,43 @@
+package com.sbuslab.utils.config.logger;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+public class LoggerConfigurationParserTest {
+
+    @Test
+    public void correctlyParsesLoggerConfigurations() {
+        final Config config = ConfigFactory.parseString(
+                "sbuslab.loggers = {\n" +
+                "   \"a.b.c\" = \"INFO\"\n" +
+                "   \"a.b.c.Class\" = \"DEBUG\"\n" +
+                "   \"b.c.d\" = \"WARN\"\n" +
+                "   c.d.e.Class = \"ERROR\"\n" +
+                "}\n" +
+                "sbuslab.loggers.\"d.e.f\" = \"TRACE\"\n" +
+                "sbuslab.loggers.d.e.f.Class = \"INFO\"\n" +
+                "sbuslab.loggers.d.e.f.Class2 = \"WARN\"\n" +
+                "sbuslab.loggers.e.f.g = \"DEBUG\"\n" +
+                "sbuslab.loggers.\"f.g.h\" = \"INFO\"\n"
+        );
+        final Set<LoggerConfigurationData> result = LoggerConfigurationParser.parseLoggersConfiguration(config);
+        assertEquals(
+                Set.of(
+                        new LoggerConfigurationData("a.b.c", "INFO"),
+                        new LoggerConfigurationData("a.b.c.Class", "DEBUG"),
+                        new LoggerConfigurationData("b.c.d", "WARN"),
+                        new LoggerConfigurationData("c.d.e.Class", "ERROR"),
+                        new LoggerConfigurationData("d.e.f", "TRACE"),
+                        new LoggerConfigurationData("d.e.f.Class", "INFO"),
+                        new LoggerConfigurationData("d.e.f.Class2", "WARN"),
+                        new LoggerConfigurationData("e.f.g", "DEBUG"),
+                        new LoggerConfigurationData("f.g.h", "INFO")
+                ),
+                result);
+    }
+}


### PR DESCRIPTION
Modified `default-json-logback.xml` so that the level of the root logger can be configured via the `ROOT_LOG_LEVEL` env variable (defaulting to trace for backwards-compatibility). 
Created the `LoggerConfigurationParser` class which handles the parsing of `sbuslab.loggers` config properties (allowing to provide them as java opts, e.g. `-Dsbuslab.loggers.package.name=INFO`). The idea behind this is to be able to override the root logger's level for specific packages/classes. Included unit tests. 
Refactored `DefaultConfiguration` to use the new `LoggerConfigurationParser` class. Included a `@PostConstruct` method so logging config is applied as soon as the context is started (before other beans are initialized yet).